### PR TITLE
Add greet_multiple sub-module that can say hello to a list of names

### DIFF
--- a/examples/hello_multiple/.terraform-docs.yml
+++ b/examples/hello_multiple/.terraform-docs.yml
@@ -1,0 +1,15 @@
+formatter: "markdown"
+
+output:
+  file: README.md
+  mode: inject
+
+recursive:
+  enabled: true
+  path: ./
+
+sections:
+  show:
+    - modules
+    - inputs
+    - outputs

--- a/examples/hello_multiple/README.md
+++ b/examples/hello_multiple/README.md
@@ -1,0 +1,26 @@
+# Hello Multiple
+This example demoinstrates how to use the [greet_multiple](../../modules/greet_multiple/) module that extends the [Hello World!](../../) module to use a list of strings.
+
+## Usage
+1. From inside this directory run `terraform init`
+2. Then run `terraform apply`
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_greet_multiple"></a> [greet\_multiple](#module\_greet\_multiple) | ../../modules/greet_multiple | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_friends"></a> [friends](#input\_friends) | A list of people/things to greet. | `list(string)` | <pre>[<br>  "Terraform",<br>  "Terratest",<br>  "Terraform Weekly"<br>]</pre> | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_result"></a> [result](#output\_result) | The resul of calling the hello\_world submodule greet\_multiple. |
+<!-- END_TF_DOCS -->

--- a/examples/hello_multiple/main.tf
+++ b/examples/hello_multiple/main.tf
@@ -1,0 +1,5 @@
+module "greet_multiple" {
+  source = "../../modules/greet_multiple"
+
+  names = var.friends
+}

--- a/examples/hello_multiple/outputs.tf
+++ b/examples/hello_multiple/outputs.tf
@@ -1,0 +1,4 @@
+output "result" {
+  description = "The resul of calling the hello_world submodule greet_multiple."
+  value       = module.greet_multiple.greeting
+}

--- a/examples/hello_multiple/variables.tf
+++ b/examples/hello_multiple/variables.tf
@@ -1,0 +1,5 @@
+variable "friends" {
+  type        = list(string)
+  default     = ["Terraform", "Terratest", "Terraform Weekly"]
+  description = "A list of people/things to greet."
+}

--- a/modules/greet_multiple/.terraform-docs.yml
+++ b/modules/greet_multiple/.terraform-docs.yml
@@ -1,0 +1,15 @@
+formatter: "markdown"
+
+output:
+  file: README.md
+  mode: inject
+
+recursive:
+  enabled: true
+  path: ./
+
+sections:
+  show:
+    - modules
+    - inputs
+    - outputs

--- a/modules/greet_multiple/README.md
+++ b/modules/greet_multiple/README.md
@@ -1,0 +1,22 @@
+# Greet Multiple
+Greet multiple is a Higher-order module, which is Terraform's version of a [Higher-Order Function](https://en.wikipedia.org/wiki/Higher-order_function). Greet Multiple extends the capabiliy of the [Hello World!](../../) module by changing the input from a string to a list of strings.
+
+<!-- BEGIN_TF_DOCS -->
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_hello"></a> [hello](#module\_hello) | ../../ | n/a |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_names"></a> [names](#input\_names) | A list of people/things to greet. | `list(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_greeting"></a> [greeting](#output\_greeting) | A friendly greeting to all of our friends! |
+<!-- END_TF_DOCS -->

--- a/modules/greet_multiple/main.tf
+++ b/modules/greet_multiple/main.tf
@@ -2,7 +2,7 @@ locals {
   len      = length(var.names)
   csv_list = slice(var.names, 0, local.len - 1)
   and_list = slice(var.names, local.len - 1, local.len)
-  input    = "${join(", ", local.csv_list)} and ${one(local.and_list)}"
+  input    = "${join(", ", local.csv_list)} and ${local.and_list[0]}"
 }
 
 module "hello" {

--- a/modules/greet_multiple/main.tf
+++ b/modules/greet_multiple/main.tf
@@ -1,0 +1,12 @@
+locals {
+  len      = length(var.names)
+  csv_list = slice(var.names, 0, local.len - 1)
+  and_list = slice(var.names, local.len - 1, local.len)
+  input    = "${join(", ", local.csv_list)} and ${one(local.and_list)}"
+}
+
+module "hello" {
+  source = "../../"
+
+  name = local.input
+}

--- a/modules/greet_multiple/outputs.tf
+++ b/modules/greet_multiple/outputs.tf
@@ -1,0 +1,4 @@
+output "greeting" {
+  description = "A friendly greeting to all of our friends!"
+  value       = module.hello.greeting
+}

--- a/modules/greet_multiple/variables.tf
+++ b/modules/greet_multiple/variables.tf
@@ -1,0 +1,4 @@
+variable "names" {
+  type        = list(string)
+  description = "A list of people/things to greet."
+}

--- a/tests/module_test.go
+++ b/tests/module_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestHelloWorldExample(t *testing.T) {
+func TestHelloWorld(t *testing.T) {
 
 	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: "../examples/hello_world",
@@ -23,7 +23,7 @@ func TestHelloWorldExample(t *testing.T) {
 	assert.Equal(t, "Hello, World!", output)
 }
 
-func TestCustomInput(t *testing.T) {
+func TestHelloCustom(t *testing.T) {
 
 	var name string = "DontShaveTheYak"
 

--- a/tests/module_test.go
+++ b/tests/module_test.go
@@ -44,3 +44,25 @@ func TestCustomInput(t *testing.T) {
 
 	assert.Equal(t, expectedOutput, output)
 }
+
+func TestHelloMultiple(t *testing.T) {
+
+	var names = []interface{}{"DSTY", "TFWeekly", "TerraTest"}
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: "../examples/hello_multiple",
+		Vars: map[string]interface{}{
+			"friends": names,
+		},
+	})
+
+	defer terraform.Destroy(t, terraformOptions)
+
+	terraform.InitAndApply(t, terraformOptions)
+
+	output := terraform.Output(t, terraformOptions, "result")
+
+	expectedOutput := fmt.Sprintf("Hello, %s, %s and %s!", names...)
+
+	assert.Equal(t, expectedOutput, output)
+}


### PR DESCRIPTION
This sub-module is a bit unique, it acts as a "Higher-order function". It extends the root module to take a list of strings.

This is a really important concept to understand. Many times I see engineers who have created a module that can take a resource ID or optionally create that resource for you. They achieve this by adding conditionals and extra variables and putting count on resources. Instead, you could achieve the same effect by having the main module take the resource id as a variable and using a higher-order sub-module to create the resource and then call the main module.