### PR TITLE
Update aws tflint rules

### DIFF
--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "aws" {
   enabled = true
-  version = "0.14.0"
+  version = "0.17.1"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }

--- a/examples/hello_custom/terraform.tf
+++ b/examples/hello_custom/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/hello_multiple/terraform.tf
+++ b/examples/hello_multiple/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/examples/hello_world/terraform.tf
+++ b/examples/hello_world/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/greet_multiple/terraform.tf
+++ b/modules/greet_multiple/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/make_exciting/terraform.tf
+++ b/modules/make_exciting/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/modules/say_hello/terraform.tf
+++ b/modules/say_hello/terraform.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
This change enforces a terraform block for all examples and sub-modules, which seems like the correct thing to do. I was confused about the sub-modules at first but then I remembered you can call a submodule directly without using the main module. 