### PR TITLE
Upgrade Go and tflint plugins

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -26,10 +26,10 @@ RUN apt update && apt -y install --no-install-recommends \
 ENV DEBIAN_FRONTEND=dialog
 
 # Install GO
-RUN wget https://go.dev/dl/go1.18.3.linux-amd64.tar.gz \
+RUN wget https://go.dev/dl/go1.22.2.linux-amd64.tar.gz \
     && rm -rf /usr/local/go \
-    && tar -C /usr/local -xzf go1.18.3.linux-amd64.tar.gz \
-    && rm -rf go1.18.3.linux-amd64.tar.gz
+    && tar -C /usr/local -xzf go1.22.2.linux-amd64.tar.gz \
+    && rm -rf go1.22.2.linux-amd64.tar.gz
 
 ENV PATH /usr/local/go/bin:$PATH
 

--- a/.github/workflows/pr_label.yml
+++ b/.github/workflows/pr_label.yml
@@ -4,6 +4,8 @@ on:
   pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
+permissions: read-all
+
 jobs:
   label:
     name: Check Labels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,16 @@ on:
   pull_request:
     types: closed
 
+permissions: read-all
+
 jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged && github.base_ref == 'main'
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Create Release
         uses: release-drafter/release-drafter@v5.15.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ on:
       - '.github/workflows/release.yml'
       - '.github/workflows/pr_checks.yml'
 
+permissions: read-all
+
 jobs:
   pre_commit:
     runs-on: ubuntu-latest

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,5 +1,5 @@
 plugin "aws" {
   enabled = true
-  version = "0.17.1"
+  version = "0.30.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }


### PR DESCRIPTION
This MR also changes the permissions on the CICD pipelines so that they use the lowest permissions needed.