### PR TITLE
fix permissions for test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
   pre_commit:
     runs-on: ubuntu-latest
     name: Pre-commit
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3.6.0


### PR DESCRIPTION
These additional permissions are needed so the dev container can be
pushed to the registry for caching.